### PR TITLE
Fix indentation

### DIFF
--- a/web/controllers/auth.ex
+++ b/web/controllers/auth.ex
@@ -14,9 +14,9 @@ defmodule Rumbl.Auth do
 
   def login(conn, user) do
     conn
-      |> assign(:current_user, user)
-      |> put_session(:user_id, user.id)
-      |> configure_session(renew: true)
+    |> assign(:current_user, user)
+    |> put_session(:user_id, user.id)
+    |> configure_session(renew: true)
   end
 
   def login_by_username_and_pass(conn, username, given_pass, opts) do
@@ -46,9 +46,9 @@ defmodule Rumbl.Auth do
       conn
     else
       conn
-        |> put_flash(:error, "You must be logged in to access that page")
-        |> redirect(to: Helpers.page_path(conn, :index))
-        |> halt()
+      |> put_flash(:error, "You must be logged in to access that page")
+      |> redirect(to: Helpers.page_path(conn, :index))
+      |> halt()
     end
   end
 end

--- a/web/controllers/session_controller.ex
+++ b/web/controllers/session_controller.ex
@@ -7,19 +7,20 @@ defmodule Rumbl.SessionController do
 
   def create(conn, %{"session" => %{"username" => user, "password" => pass}}) do
     case Rumbl.Auth.login_by_username_and_pass(conn, user, pass, repo: Repo) do
-      {:ok, conn} -> conn
+      {:ok, conn} ->
+        conn
         |> put_flash(:info, "Welcome back!")
         |> redirect(to: page_path(conn, :index))
       {:error, _reason, conn} ->
         conn
-          |> put_flash(:error, "Invalid username/password combination")
-          |> render("new.html")
+        |> put_flash(:error, "Invalid username/password combination")
+        |> render("new.html")
     end
   end
 
   def delete(conn, _) do
     conn
-      |> Rumbl.Auth.logout()
-      |> redirect(to: page_path(conn, :index))
+    |> Rumbl.Auth.logout()
+    |> redirect(to: page_path(conn, :index))
   end
 end

--- a/web/controllers/user_controller.ex
+++ b/web/controllers/user_controller.ex
@@ -23,9 +23,9 @@ defmodule Rumbl.UserController do
     case Repo.insert(changeset) do
       {:ok, user} ->
         conn
-          |> Rumbl.Auth.login(user)
-          |> put_flash(:info, "#{user.name} created!")
-          |> redirect(to: user_path(conn, :index))
+        |> Rumbl.Auth.login(user)
+        |> put_flash(:info, "#{user.name} created!")
+        |> redirect(to: user_path(conn, :index))
       {:error, changeset} ->
         render(conn, "new.html", changeset: changeset)
     end

--- a/web/models/user.ex
+++ b/web/models/user.ex
@@ -1,13 +1,13 @@
 defmodule Rumbl.User do
   use Rumbl.Web, :model
-    schema "users" do
-      field :name, :string
-      field :username, :string
-      field :password, :string, virtual: true
-      field :password_hash, :string
-    
 
-      timestamps()
+  schema "users" do
+    field :name, :string
+    field :username, :string
+    field :password, :string, virtual: true
+    field :password_hash, :string
+
+    timestamps()
   end
 
   def changeset(model, params \\ :invalid) do
@@ -19,9 +19,9 @@ defmodule Rumbl.User do
 
   def registration_changeset(model, params) do
     model
-      |> changeset(params)
-      |> cast(params, ~w(password), [])
-      |> validate_length(:password, min: 6, max: 100) |> put_pass_hash()
+    |> changeset(params)
+    |> cast(params, ~w(password), [])
+    |> validate_length(:password, min: 6, max: 100) |> put_pass_hash()
   end
 
   defp put_pass_hash(changeset) do
@@ -29,8 +29,7 @@ defmodule Rumbl.User do
       %Ecto.Changeset{valid?: true, changes: %{password: pass}} ->
         put_change(changeset, :password_hash, Comeonin.Bcrypt.hashpwsalt(pass))
       _ ->
-      changeset
+        changeset
     end
   end
-
 end

--- a/web/templates/actor/index.html.eex
+++ b/web/templates/actor/index.html.eex
@@ -1,10 +1,10 @@
 <div class="flex-container">
   <p class="name">Hugh</p>
-<div class="firstimage"></div>
-<p class="name">Henry</p>
-<div class="secondimage"></div>
-<p class="name">Benedict</p>
-<div class="thridimage"></div>
+  <div class="firstimage"></div>
+  <p class="name">Henry</p>
+  <div class="secondimage"></div>
+  <p class="name">Benedict</p>
+  <div class="thridimage"></div>
 </div>
 
 <div class="flex-container">

--- a/web/templates/layout/app.html.eex
+++ b/web/templates/layout/app.html.eex
@@ -16,19 +16,19 @@
       <div class="header">
         <ol class="breadcrumb text-right">
           <%= if @current_user do %>
-          <li>
-            <%= @current_user.username %>
-          </li>
-          <li>
-            <%= link "Log out", to: session_path(@conn, :delete, @current_user), method: "delete" %>
-          </li>
+            <li>
+              <%= @current_user.username %>
+            </li>
+            <li>
+              <%= link "Log out", to: session_path(@conn, :delete, @current_user), method: "delete" %>
+            </li>
           <% else %>
-          <li>
-          <%= link "Register", to: user_path(@conn, :new) %>
-          </li>
-          <li>
-            <%= link "Log in", to: session_path(@conn, :new) %>
-          </li>
+            <li>
+              <%= link "Register", to: user_path(@conn, :new) %>
+            </li>
+            <li>
+              <%= link "Log in", to: session_path(@conn, :new) %>
+            </li>
           <% end %>
         </ol>
         <p class="text">Welcome to Ratings App</p>
@@ -46,7 +46,7 @@
 
       <div class = "mysecondcontent">
         <main role="main">
-          <%= render @view_module, @view_template, assigns %>
+        <%= render @view_module, @view_template, assigns %>
         </main>
       </div>
     </div>
@@ -54,4 +54,4 @@
 
     <script src="<%= static_path(@conn, "/js/app.js") %>"></script>
   </body>
-  </html>
+</html>

--- a/web/templates/session/new.html.eex
+++ b/web/templates/session/new.html.eex
@@ -1,13 +1,13 @@
 <h1 class="login">Login</h1>
 <div class="fonts">
-<%= form_for @conn, session_path(@conn, :create), [as: :session], fn f -> %>
-  <div class="form-group">
-    <%= text_input f, :username, placeholder: "Username", class: "form-control" %>
-  </div>
+  <%= form_for @conn, session_path(@conn, :create), [as: :session], fn f -> %>
+    <div class="form-group">
+      <%= text_input f, :username, placeholder: "Username", class: "form-control" %>
+    </div>
 
-  <div class="form-group">
-    <%= password_input f, :password, placeholder: "Password", class: "form-control" %>
-  </div>
-<%= submit "Log in", class: "btn btn-primary" %>
+    <div class="form-group">
+      <%= password_input f, :password, placeholder: "Password", class: "form-control" %>
+    </div>
+    <%= submit "Log in", class: "btn btn-primary" %>
 </div>
 <% end %>

--- a/web/templates/user/index.html.eex
+++ b/web/templates/user/index.html.eex
@@ -2,9 +2,9 @@
 
 <table class="table">
   <%= for user <- @users do %>
-  <tr>
-    <td><%= render "user.html", user: user %></td>
-    <td><%= link "View", to: user_path(@conn, :show, user.id) %></td>
-  </tr>
+    <tr>
+      <td><%= render "user.html", user: user %></td>
+      <td><%= link "View", to: user_path(@conn, :show, user.id) %></td>
+    </tr>
   <% end %>
 </table>

--- a/web/templates/user/new.html.eex
+++ b/web/templates/user/new.html.eex
@@ -8,18 +8,18 @@
     </div>
   <% end %>
   <div class="fonts">
-  <div class="form-group">
-    <%= text_input f, :name, placeholder: "Name", class: "form-control" %>
-    <%= error_tag f, :name %>
-  </div>
-  <div class="form-group">
-    <%= text_input f, :username, placeholder: "Username", class: "form-control" %>
-    <%= error_tag f, :username %> </div>
-  <div class="form-group">
-    <%= password_input f, :password, placeholder: "Password", class: "form-control" %>
-    <%= error_tag f, :password %>
-  </div>
+    <div class="form-group">
+      <%= text_input f, :name, placeholder: "Name", class: "form-control" %>
+      <%= error_tag f, :name %>
+    </div>
+    <div class="form-group">
+      <%= text_input f, :username, placeholder: "Username", class: "form-control" %>
+      <%= error_tag f, :username %> </div>
+    <div class="form-group">
+      <%= password_input f, :password, placeholder: "Password", class: "form-control" %>
+      <%= error_tag f, :password %>
+    </div>
 
-  <%= submit "Create User", class: "btn btn-primary" %>
-</div>
+    <%= submit "Create User", class: "btn btn-primary" %>
+  </div>
 <% end %>

--- a/web/views/user_view.ex
+++ b/web/views/user_view.ex
@@ -4,7 +4,7 @@ defmodule Rumbl.UserView do
 
   def first_name(%User{name: name}) do
     name
-      |> String.split(" ")
-      |> Enum.at(0)
+    |> String.split(" ")
+    |> Enum.at(0)
   end
 end


### PR DESCRIPTION
One of the biggest irregularities here was stuff like this:

    some_var
      |> piped_through_thing_1
      |> and_also_through_thing_2

The convention in Elixir is to indent the successive lines that start with the pipe, `|>`, to the same indentation level as the first line, like this:

    some_var
    |> piped_through_thing_1
    |> and_also_through_thing_2

I understand wanting to indent these the other way, but I think it's important to get used to the convention, as it's what you're going to see when you read Elixir code out on the web.

Other than that, I think I saw a couple things that indicate that you might not fully understand how to read `case` statements in Elixir.  Refresh your memory on that!  https://elixirschool.com/en/lessons/basics/control-structures/